### PR TITLE
Fix azlmbr paths to use project centric approach over engine centric.

### DIFF
--- a/Gem/PythonTests/Automated/atom_utils/automated_test_base.py
+++ b/Gem/PythonTests/Automated/atom_utils/automated_test_base.py
@@ -65,12 +65,6 @@ class TestAutomationBase:
         new_log_monitor.monitor_log_for_lines(expected_lines, unexpected_lines)
         editor.stop()
 
-    def _get_project_path(self, workspace):
-        """
-        return the full path of the project in this workspace
-        """
-        return os.path.join(workspace.paths.engine_root(), workspace.project)
-
     def _capture_screenshot(self):
         """
         Captures a screenshot from Atom
@@ -102,7 +96,7 @@ class TestAutomationBase:
             logger.warning("level_dir is empty, nothing to delete.")
             return
 
-        full_level_dir = os.path.join(self._get_project_path(workspace), 'Levels', level_dir)
+        full_level_dir = os.path.join(workspace.paths.project(), 'Levels', level_dir)
         if (not os.path.isdir(full_level_dir)):
             if (os.path.exists(full_level_dir)):
                 logger.error("level '{}' isn't a directory, it won't be deleted.".format(full_level_dir))

--- a/Gem/PythonTests/Automated/test_suites/main/AllLevelsOpenClose_test.py
+++ b/Gem/PythonTests/Automated/test_suites/main/AllLevelsOpenClose_test.py
@@ -33,11 +33,11 @@ class TestAllLevels(object):
     @pytest.fixture(autouse=True)
     def setup_teardown(self, request, workspace, project, level):
         # Cleanup our temp level
-        file_system.delete([os.path.join(workspace.paths.engine_root(), project, "Levels", level)], True, True)
+        file_system.delete([os.path.join(workspace.paths.project(), "Levels", level)], True, True)
 
         def teardown():
             # Cleanup our temp level
-            file_system.delete([os.path.join(workspace.paths.engine_root(), project, "Levels", level)], True, True)
+            file_system.delete([os.path.join(workspace.paths.project(), "Levels", level)], True, True)
 
         request.addfinalizer(teardown)
 

--- a/Gem/PythonTests/Automated/test_suites/main/AllLevelsOpenClose_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/main/AllLevelsOpenClose_test_case.py
@@ -14,7 +14,7 @@ import sys
 import azlmbr.legacy.general as general
 import azlmbr.paths
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.automated_test_utils import TestHelper as helper
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/ActorComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/ActorComponent_test.py
@@ -30,7 +30,7 @@ class TestAutomation(TestAutomationBase):
         """
         golden_screenshot = os.path.join(golden_images_directory, 'Windows', 'ActorComponent.ppm')
         test_screenshot = os.path.join(
-            workspace.paths.engine_root(), project, DEFAULT_SUBFOLDER_PATH, 'screenshot_atom_ActorComponent.ppm')
+            workspace.paths.project(), DEFAULT_SUBFOLDER_PATH, 'screenshot_atom_ActorComponent.ppm')
 
         self.remove_artifacts([test_screenshot])
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/ActorComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/ActorComponent_test_case.py
@@ -20,7 +20,7 @@ import azlmbr.legacy.general as general
 import azlmbr.paths
 from azlmbr.entity import EntityId
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.automated_test_utils import TestHelper as helper
 from Automated.atom_utils.screenshot_utils import ScreenshotHelper

--- a/Gem/PythonTests/Automated/test_suites/periodic/AllComponentsBasicTests_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/AllComponentsBasicTests_test_case.py
@@ -20,7 +20,7 @@ import azlmbr.legacy.general as general
 import azlmbr.editor as editor
 import azlmbr.render as render
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AutomatedTesting", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 import editor_python_test_tools.hydra_editor_utils as hydra
 from editor_python_test_tools.utils import TestHelper

--- a/Gem/PythonTests/Automated/test_suites/periodic/AllComponentsIndepthTests_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/AllComponentsIndepthTests_test.py
@@ -36,7 +36,7 @@ class TestAllComponentsIndepthTests(TestAutomationBase):
         Tests that a basic rendering level setup can be created (lighting, meshes, materials, etc.).
         """
         cache_images = [os.path.join(
-            workspace.paths.engine_root(), project, DEFAULT_SUBFOLDER_PATH, screenshot_name)]
+            workspace.paths.project(), DEFAULT_SUBFOLDER_PATH, screenshot_name)]
         self.remove_artifacts(cache_images)
 
         golden_images = [os.path.join(golden_images_directory, "Windows", "AllComponentsIndepthTests", screenshot_name)]
@@ -89,7 +89,7 @@ class TestAllComponentsIndepthTests(TestAutomationBase):
 
         cache_images = []
         for cache_image in screenshot_names:
-            screenshot_path = os.path.join(workspace.paths.engine_root(), project, DEFAULT_SUBFOLDER_PATH, cache_image)
+            screenshot_path = os.path.join(workspace.paths.project(), DEFAULT_SUBFOLDER_PATH, cache_image)
             cache_images.append(screenshot_path)
         self.remove_artifacts(cache_images)
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/AllComponentsIndepthTests_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/AllComponentsIndepthTests_test_case.py
@@ -19,7 +19,7 @@ import azlmbr.math as math
 import azlmbr.paths
 import azlmbr.legacy.general as general
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils import hydra_editor_utils as hydra
 from Automated.atom_utils.automated_test_utils import TestHelper as helper

--- a/Gem/PythonTests/Automated/test_suites/periodic/AssetCollectionLoadManager_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/AssetCollectionLoadManager_test_case.py
@@ -25,7 +25,7 @@ import azlmbr.paths
 import azlmbr.asset as asset
 from azlmbr.entity import EntityId
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.automated_test_utils import TestHelper as helper
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/BasicLevelSetup_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/BasicLevelSetup_test_case.py
@@ -15,7 +15,7 @@ import sys
 import azlmbr.paths
 import azlmbr.legacy.general as general
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 import Automated.atom_utils.hydra_editor_utils as hydra
 from Automated.atom_utils.automated_test_utils import TestHelper as helper

--- a/Gem/PythonTests/Automated/test_suites/periodic/ChangingMaterialTabs_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/ChangingMaterialTabs_test_case.py
@@ -22,7 +22,7 @@ from PySide2 import QtWidgets, QtTest, QtCore
 
 import azlmbr.paths
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from editor_python_test_tools import pyside_utils
 from Automated.atom_utils.material_editor_utils import MaterialEditorHelper

--- a/Gem/PythonTests/Automated/test_suites/periodic/CreatingChildMaterials_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/CreatingChildMaterials_test_case.py
@@ -22,7 +22,7 @@ import time
 import azlmbr.paths
 import azlmbr.math as math
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.material_editor_utils import MaterialEditorHelper
 import Automated.atom_utils.material_editor_utils as material_editor_utils

--- a/Gem/PythonTests/Automated/test_suites/periodic/CreatingSubfoldersInLibrary_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/CreatingSubfoldersInLibrary_test_case.py
@@ -23,7 +23,7 @@ from PySide2 import QtWidgets
 
 import azlmbr.paths
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from editor_python_test_tools import pyside_utils
 from Automated.atom_utils.material_editor_utils import MaterialEditorHelper

--- a/Gem/PythonTests/Automated/test_suites/periodic/DecalComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/DecalComponent_test.py
@@ -31,7 +31,7 @@ class TestAutomation(TestAutomationBase):
         golden_screenshot = os.path.join(golden_images_directory, 'Windows', 'DecalComponent.ppm')
         
         test_screenshot = os.path.join(
-            workspace.paths.engine_root(), project, DEFAULT_SUBFOLDER_PATH, 'screenshot_atom_DecalComponent.ppm')
+            workspace.paths.project(), DEFAULT_SUBFOLDER_PATH, 'screenshot_atom_DecalComponent.ppm')
         print(test_screenshot)
 
         self.remove_artifacts([

--- a/Gem/PythonTests/Automated/test_suites/periodic/DecalComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/DecalComponent_test_case.py
@@ -19,7 +19,7 @@ import azlmbr.legacy.general as general
 import azlmbr.paths
 from azlmbr.entity import EntityId
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.automated_test_utils import TestHelper as helper
 from Automated.atom_utils.hydra_editor_utils import helper_create_entity_with_mesh

--- a/Gem/PythonTests/Automated/test_suites/periodic/DirectionalLightComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/DirectionalLightComponent_test.py
@@ -32,7 +32,7 @@ class TestAutomation(TestAutomationBase):
             golden_images_directory, 'Windows', 'atom_directionallight')
         
         test_screenshot_base = os.path.join(
-            workspace.paths.engine_root(), project, DEFAULT_SUBFOLDER_PATH, 'screenshot_atom_directionallight')
+            workspace.paths.project(), DEFAULT_SUBFOLDER_PATH, 'screenshot_atom_directionallight')
         
         golden_screenshots = []
         test_screenshots = []

--- a/Gem/PythonTests/Automated/test_suites/periodic/DirectionalLightComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/DirectionalLightComponent_test_case.py
@@ -23,7 +23,7 @@ import azlmbr.legacy.general as general
 import azlmbr.math
 import azlmbr.paths
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.automated_test_utils import TestHelper as helper
 from Automated.atom_utils.screenshot_utils import ScreenshotHelper

--- a/Gem/PythonTests/Automated/test_suites/periodic/ExposureComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/ExposureComponent_test.py
@@ -34,9 +34,9 @@ class TestAutomation(TestAutomationBase):
         ]
 
         test_screenshots = [
-            os.path.join(workspace.paths.engine_root(), project, DEFAULT_SUBFOLDER_PATH,
+            os.path.join(workspace.paths.project(), DEFAULT_SUBFOLDER_PATH,
                          'screenshot_atom_ExposureComponent_Manual.ppm'),
-            os.path.join(workspace.paths.engine_root(), project, DEFAULT_SUBFOLDER_PATH,
+            os.path.join(workspace.paths.project(), DEFAULT_SUBFOLDER_PATH,
                          'screenshot_atom_ExposureComponent_EyeAdaptation.ppm')
         ]
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/ExposureComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/ExposureComponent_test_case.py
@@ -20,7 +20,7 @@ import azlmbr.legacy.general as general
 import azlmbr.paths
 from azlmbr.entity import EntityId
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.automated_test_utils import TestHelper as helper
 from Automated.atom_utils.screenshot_utils import ScreenshotHelper

--- a/Gem/PythonTests/Automated/test_suites/periodic/GridComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/GridComponent_test.py
@@ -30,7 +30,7 @@ class TestAutomation(TestAutomationBase):
         """
         golden_screenshot = os.path.join(golden_images_directory, 'Windows', "GridComponent.ppm")
         test_screenshot = os.path.join(
-            workspace.paths.engine_root(), project, DEFAULT_SUBFOLDER_PATH, "screenshot_atom_GridComponent.ppm")
+            workspace.paths.project(), DEFAULT_SUBFOLDER_PATH, "screenshot_atom_GridComponent.ppm")
         self.remove_artifacts([test_screenshot])
 
         expected_lines = [

--- a/Gem/PythonTests/Automated/test_suites/periodic/GridComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/GridComponent_test_case.py
@@ -17,7 +17,7 @@ import azlmbr.editor
 import azlmbr.legacy.general as general
 from azlmbr.entity import EntityId
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.automated_test_utils import TestHelper as helper
 from Automated.atom_utils.screenshot_utils import ScreenshotHelper

--- a/Gem/PythonTests/Automated/test_suites/periodic/HDRiSkyboxComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/HDRiSkyboxComponent_test.py
@@ -30,7 +30,7 @@ class TestAutomation(TestAutomationBase):
         """
         golden_screenshot = os.path.join(golden_images_directory, 'Windows', 'HDRiSkyboxComponent.ppm')
         test_screenshot = os.path.join(
-            workspace.paths.engine_root(), project, DEFAULT_SUBFOLDER_PATH, 'screenshot_atom_HDRiSkyboxComponent.ppm')
+            workspace.paths.project(), DEFAULT_SUBFOLDER_PATH, 'screenshot_atom_HDRiSkyboxComponent.ppm')
         self.remove_artifacts([test_screenshot])
 
         expected_lines = [

--- a/Gem/PythonTests/Automated/test_suites/periodic/HDRiSkyboxComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/HDRiSkyboxComponent_test_case.py
@@ -19,7 +19,7 @@ import azlmbr.legacy.general as general
 import azlmbr.paths
 from azlmbr.entity import EntityId
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.automated_test_utils import TestHelper as helper
 from Automated.atom_utils.screenshot_utils import ScreenshotHelper

--- a/Gem/PythonTests/Automated/test_suites/periodic/MaterialBrowserSearchAssets_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MaterialBrowserSearchAssets_test_case.py
@@ -21,7 +21,7 @@ import azlmbr.paths
 from editor_python_test_tools import pyside_utils
 from PySide2 import QtWidgets, QtCore
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.material_editor_utils import MaterialEditorHelper
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/MaterialComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MaterialComponent_test_case.py
@@ -18,7 +18,7 @@ import azlmbr.editor
 import azlmbr.legacy.general as general
 import azlmbr.paths
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.automated_test_utils import TestHelper as helper
 from Automated.atom_utils.screenshot_utils import ScreenshotHelper

--- a/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditorBasicTests_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditorBasicTests_test_case.py
@@ -17,7 +17,7 @@ import azlmbr.math as math
 import azlmbr.asset as asset
 import azlmbr.bus as bus
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 import Automated.atom_utils.material_editor_utils as material_editor
 from Automated.atom_utils.material_editor_utils import MaterialEditorHelper

--- a/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditorExitFromFileMenu_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditorExitFromFileMenu_test_case.py
@@ -17,7 +17,7 @@ import azlmbr.paths
 from editor_python_test_tools import pyside_utils
 from PySide2 import QtWidgets
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 from Automated.atom_utils.material_editor_utils import MaterialEditorHelper
 
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditor_EnableGridShadowCatcherLight_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditor_EnableGridShadowCatcherLight_test.py
@@ -33,13 +33,13 @@ class TestMaterialEditorEnableGridShadowCatcherLight(TestAutomationBase):
         ]
 
         test_screenshots = [
-            os.path.join(workspace.paths.engine_root(), project, 'Cache', 'pc', 'Screenshots', 'screenshot_materialeditor_cube.ppm'),
-            os.path.join(workspace.paths.engine_root(), project, 'Cache', 'pc', 'Screenshots', 'screenshot_materialeditor_griddisable.ppm'),
-            os.path.join(workspace.paths.engine_root(), project, 'Cache', 'pc', 'Screenshots', 'screenshot_materialeditor_gridenable.ppm'),
-            os.path.join(workspace.paths.engine_root(), project, 'Cache', 'pc', 'Screenshots', 'screenshot_materialeditor_light.ppm'),
-            os.path.join(workspace.paths.engine_root(), project, 'Cache', 'pc', 'Screenshots', 'screenshot_materialeditor_shaderball.ppm'),
-            os.path.join(workspace.paths.engine_root(), project, 'Cache', 'pc', 'Screenshots', 'screenshot_materialeditor_shadowdisable.ppm'),
-            os.path.join(workspace.paths.engine_root(), project, 'Cache', 'pc', 'Screenshots', 'screenshot_materialeditor_shadowenable.ppm'),
+            os.path.join(workspace.paths.project(), 'Cache', 'pc', 'Screenshots', 'screenshot_materialeditor_cube.ppm'),
+            os.path.join(workspace.paths.project(), 'Cache', 'pc', 'Screenshots', 'screenshot_materialeditor_griddisable.ppm'),
+            os.path.join(workspace.paths.project(), 'Cache', 'pc', 'Screenshots', 'screenshot_materialeditor_gridenable.ppm'),
+            os.path.join(workspace.paths.project(), 'Cache', 'pc', 'Screenshots', 'screenshot_materialeditor_light.ppm'),
+            os.path.join(workspace.paths.project(), 'Cache', 'pc', 'Screenshots', 'screenshot_materialeditor_shaderball.ppm'),
+            os.path.join(workspace.paths.project(), 'Cache', 'pc', 'Screenshots', 'screenshot_materialeditor_shadowdisable.ppm'),
+            os.path.join(workspace.paths.project(), 'Cache', 'pc', 'Screenshots', 'screenshot_materialeditor_shadowenable.ppm'),
         ]
 
         self.remove_artifacts(test_screenshots)

--- a/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditor_EnableGridShadowCatcherLight_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditor_EnableGridShadowCatcherLight_test_case.py
@@ -16,7 +16,7 @@ import azlmbr.materialeditor
 import azlmbr.paths
 import azlmbr.atom
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 import Automated.atom_utils.material_editor_utils as material_editor
 from Automated.atom_utils.material_editor_utils import MaterialEditorHelper, capture_screenshot

--- a/Gem/PythonTests/Automated/test_suites/periodic/MeshComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MeshComponent_test.py
@@ -30,7 +30,7 @@ class TestAutomation(TestAutomationBase):
         """
         golden_screenshot = os.path.join(golden_images_directory, 'Windows', 'MeshComponent.ppm')
         test_screenshot = os.path.join(
-            workspace.paths.engine_root(), project, DEFAULT_SUBFOLDER_PATH, 'screenshot_atom_MeshComponent.ppm')
+            workspace.paths.project(), DEFAULT_SUBFOLDER_PATH, 'screenshot_atom_MeshComponent.ppm')
         self.remove_artifacts([test_screenshot])
 
         expected_lines = [

--- a/Gem/PythonTests/Automated/test_suites/periodic/MeshComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MeshComponent_test_case.py
@@ -19,7 +19,7 @@ import azlmbr.legacy.general as general
 import azlmbr.paths
 from azlmbr.entity import EntityId
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.automated_test_utils import TestHelper as helper
 from Automated.atom_utils.screenshot_utils import ScreenshotHelper

--- a/Gem/PythonTests/Automated/test_suites/periodic/MeshGroupImporting_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MeshGroupImporting_test.py
@@ -29,7 +29,7 @@ class TestAutomation(TestAutomationBase):
         """
         golden_screenshot = os.path.join(golden_images_directory, 'Windows', 'FBXMeshGroupImportScaling.ppm')
         test_screenshot = os.path.join(
-            workspace.paths.engine_root(), project, DEFAULT_SUBFOLDER_PATH,
+            workspace.paths.project(), DEFAULT_SUBFOLDER_PATH,
             "screenshot_atom_FBXMeshGroupImportScaling.dds")
         self.remove_artifacts([test_screenshot])
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/MeshGroupImporting_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MeshGroupImporting_test_case.py
@@ -18,7 +18,7 @@ import azlmbr.legacy.general as general
 import azlmbr.math as math
 import azlmbr.editor
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.automated_test_utils import TestHelper as helper
 from Automated.atom_utils.hydra_editor_utils import helper_create_entity_with_mesh

--- a/Gem/PythonTests/Automated/test_suites/periodic/MeshScaling_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MeshScaling_test.py
@@ -47,5 +47,5 @@ class TestAutomation(TestAutomationBase):
 
         golden_screenshot = os.path.join(golden_images_directory, 'Windows', 'FBXMeshScaling.ppm')
         test_screenshot = os.path.join(
-            workspace.paths.engine_root(), project, DEFAULT_SUBFOLDER_PATH, "screenshot_atom_FBXMeshScaling.dds")
+            workspace.paths.project(), DEFAULT_SUBFOLDER_PATH, "screenshot_atom_FBXMeshScaling.dds")
         self.compare_screenshots(test_screenshot, golden_screenshot)

--- a/Gem/PythonTests/Automated/test_suites/periodic/MeshScaling_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MeshScaling_test_case.py
@@ -18,7 +18,7 @@ import azlmbr.legacy.general as general
 import azlmbr.math as math
 import azlmbr.paths
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.automated_test_utils import TestHelper as helper
 from Automated.atom_utils.hydra_editor_utils import helper_create_entity_with_mesh

--- a/Gem/PythonTests/Automated/test_suites/periodic/NonMaterialAssetsExcludedInBrowser_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/NonMaterialAssetsExcludedInBrowser_test_case.py
@@ -22,7 +22,7 @@ from PySide2 import QtWidgets
 
 import azlmbr.paths
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from editor_python_test_tools import pyside_utils
 from Automated.atom_utils.material_editor_utils import MaterialEditorHelper

--- a/Gem/PythonTests/Automated/test_suites/periodic/OpeningFileSourceLocation_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/OpeningFileSourceLocation_test_case.py
@@ -21,7 +21,7 @@ import azlmbr.paths
 from editor_python_test_tools import pyside_utils
 from PySide2 import QtWidgets
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.material_editor_utils import MaterialEditorHelper
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/OpeningMaterialAssetBrowser_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/OpeningMaterialAssetBrowser_test_case.py
@@ -22,7 +22,7 @@ import azlmbr.paths
 from editor_python_test_tools import pyside_utils
 from PySide2 import QtWidgets, QtCore, QtTest
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.material_editor_utils import MaterialEditorHelper
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/PhysicalSkyComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/PhysicalSkyComponent_test.py
@@ -30,7 +30,7 @@ class TestAutomation(TestAutomationBase):
         """
         golden_screenshot = os.path.join(golden_images_directory, 'Windows', 'PhysicalSkyComponent.ppm')
         test_screenshot = os.path.join(
-            workspace.paths.engine_root(), project, DEFAULT_SUBFOLDER_PATH, 'screenshot_atom_PhysicalSkyComponent.ppm')
+            workspace.paths.project(), DEFAULT_SUBFOLDER_PATH, 'screenshot_atom_PhysicalSkyComponent.ppm')
  
         self.remove_artifacts([test_screenshot])
  

--- a/Gem/PythonTests/Automated/test_suites/periodic/PhysicalSkyComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/PhysicalSkyComponent_test_case.py
@@ -21,7 +21,7 @@ import azlmbr.legacy.general as general
 import azlmbr.paths
 from azlmbr.entity import EntityId
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.automated_test_utils import TestHelper as helper
 from Automated.atom_utils.screenshot_utils import ScreenshotHelper

--- a/Gem/PythonTests/Automated/test_suites/periodic/PostFxGradientWeightModifierComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/PostFxGradientWeightModifierComponent_test.py
@@ -35,11 +35,11 @@ class TestAutomation(TestAutomationBase):
         ]
 
         test_screenshots = [
-            os.path.join(workspace.paths.engine_root(), project, DEFAULT_SUBFOLDER_PATH,
+            os.path.join(workspace.paths.project(), DEFAULT_SUBFOLDER_PATH,
                          'screenshot_atom_GradientWeightModifierComponent_RandomExposure1.ppm'),
-            os.path.join(workspace.paths.engine_root(), project, DEFAULT_SUBFOLDER_PATH,
+            os.path.join(workspace.paths.project(), DEFAULT_SUBFOLDER_PATH,
                          'screenshot_atom_GradientWeightModifierComponent_RandomExposure2.ppm'),
-            os.path.join(workspace.paths.engine_root(), project, DEFAULT_SUBFOLDER_PATH,
+            os.path.join(workspace.paths.project(), DEFAULT_SUBFOLDER_PATH,
                          'screenshot_atom_GradientWeightModifierComponent_NoExposure.ppm')
         ]
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/PostFxGradientWeightModifierComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/PostFxGradientWeightModifierComponent_test_case.py
@@ -19,7 +19,7 @@ import azlmbr.legacy.general as general
 import azlmbr.paths
 from azlmbr.entity import EntityId
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.screenshot_utils import ScreenshotHelper
 from Automated.atom_utils.automated_test_utils import TestHelper as helper

--- a/Gem/PythonTests/Automated/test_suites/periodic/PostFxShapeWeightModifierComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/PostFxShapeWeightModifierComponent_test.py
@@ -35,11 +35,11 @@ class TestAutomation(TestAutomationBase):
         ]
 
         test_screenshots = [
-            os.path.join(workspace.paths.engine_root(), project, DEFAULT_SUBFOLDER_PATH,
+            os.path.join(workspace.paths.project(), DEFAULT_SUBFOLDER_PATH,
                          'screenshot_atom_ShapeWeightModifierComponent_FullExposure.ppm'),
-            os.path.join(workspace.paths.engine_root(), project, DEFAULT_SUBFOLDER_PATH,
+            os.path.join(workspace.paths.project(), DEFAULT_SUBFOLDER_PATH,
                          'screenshot_atom_ShapeWeightModifierComponent_HalfExposure.ppm'),
-            os.path.join(workspace.paths.engine_root(), project, DEFAULT_SUBFOLDER_PATH,
+            os.path.join(workspace.paths.project(), DEFAULT_SUBFOLDER_PATH,
                          'screenshot_atom_ShapeWeightModifierComponent_NoExposure.ppm')
         ]
         self.remove_artifacts(test_screenshots)

--- a/Gem/PythonTests/Automated/test_suites/periodic/PostFxShapeWeightModifierComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/PostFxShapeWeightModifierComponent_test_case.py
@@ -18,7 +18,7 @@ import azlmbr.editor
 import azlmbr.legacy.general as general
 import azlmbr.paths
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.screenshot_utils import ScreenshotHelper
 from Automated.atom_utils.automated_test_utils import TestHelper as helper

--- a/Gem/PythonTests/Automated/test_suites/periodic/RadiusWeightModifierComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/RadiusWeightModifierComponent_test_case.py
@@ -20,7 +20,7 @@ import azlmbr.legacy.general as general
 import azlmbr.paths
 from azlmbr.entity import EntityId
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.screenshot_utils import ScreenshotHelper
 from Automated.atom_utils.automated_test_utils import TestHelper as helper

--- a/Gem/PythonTests/Automated/test_suites/periodic/ReloadingConfigurationFiles_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/ReloadingConfigurationFiles_test_case.py
@@ -22,7 +22,7 @@ import azlmbr.paths
 from editor_python_test_tools import pyside_utils
 from PySide2 import QtWidgets
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.material_editor_utils import MaterialEditorHelper
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/SelectingInBrowserViaViewportTab_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/SelectingInBrowserViaViewportTab_test_case.py
@@ -23,7 +23,7 @@ from PySide2 import QtWidgets
 
 import azlmbr.paths
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from editor_python_test_tools import pyside_utils
 from Automated.atom_utils.material_editor_utils import MaterialEditorHelper

--- a/Gem/PythonTests/Automated/test_suites/periodic/SelectingOpenMaterials_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/SelectingOpenMaterials_test_case.py
@@ -24,7 +24,7 @@ from PySide2 import QtWidgets, QtTest, QtCore
 
 import azlmbr.paths
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from editor_python_test_tools import pyside_utils
 from Automated.atom_utils.material_editor_utils import MaterialEditorHelper

--- a/Gem/PythonTests/Automated/test_suites/periodic/TransformManipulators_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/TransformManipulators_test_case.py
@@ -19,7 +19,7 @@ import azlmbr.editor
 import azlmbr.legacy.general as general
 import azlmbr.paths
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 from Automated.atom_utils.automated_test_utils import TestHelper as helper
 from Automated.atom_utils.screenshot_utils import ScreenshotHelper

--- a/Gem/PythonTests/Automated/test_suites/periodic/ViewAssetBrowserMaterialInspector_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/ViewAssetBrowserMaterialInspector_test_case.py
@@ -13,7 +13,7 @@ import sys
 
 import azlmbr.paths
 
-sys.path.append(os.path.join(azlmbr.paths.devroot, "AtomTest", "Gem", "PythonTests"))
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
 
 import Automated.atom_utils.material_editor_utils as material_editor
 from Automated.atom_utils.material_editor_utils import MaterialEditorHelper


### PR DESCRIPTION
- These paths should work for both engine centric and project centric. It only cares about the location of the project in either case and `azlmbr.paths.devassets` gives us that path.