### PR TITLE
Shorten copyright headers by splitting into 2 lines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Editor/Scripts/add_dccsi.py
+++ b/Editor/Scripts/add_dccsi.py
@@ -3,7 +3,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Editor/Scripts/add_dccsi.py
+++ b/Editor/Scripts/add_dccsi.py
@@ -1,7 +1,8 @@
 # coding:utf-8
 #!/usr/bin/python
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Editor/Scripts/atom/material_helper.py
+++ b/Editor/Scripts/atom/material_helper.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Editor/Scripts/atom/material_propertyOverrides_demo.py
+++ b/Editor/Scripts/atom/material_propertyOverrides_demo.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Editor/Scripts/atom/maya/__init__.py
+++ b/Editor/Scripts/atom/maya/__init__.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Editor/Scripts/atom/maya/atom_mat.py
+++ b/Editor/Scripts/atom/maya/atom_mat.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Editor/Scripts/atom/maya/fbx_to_atom.py
+++ b/Editor/Scripts/atom/maya/fbx_to_atom.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Editor/Scripts/atom/maya/stingrayPBS_converter.py
+++ b/Editor/Scripts/atom/maya/stingrayPBS_converter.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Editor/Scripts/atom/maya/stingrayPBS_converter_maya.py
+++ b/Editor/Scripts/atom/maya/stingrayPBS_converter_maya.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Editor/Scripts/atom/multi_material_random.py
+++ b/Editor/Scripts/atom/multi_material_random.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Editor/Scripts/atom/multi_material_stringray.py
+++ b/Editor/Scripts/atom/multi_material_stringray.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Editor/Scripts/bootstrap.py
+++ b/Editor/Scripts/bootstrap.py
@@ -3,7 +3,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Editor/Scripts/bootstrap.py
+++ b/Editor/Scripts/bootstrap.py
@@ -1,7 +1,8 @@
 # coding:utf-8
 #!/usr/bin/python
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/EngineFinder.cmake
+++ b/EngineFinder.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/EngineFinder.cmake
+++ b/EngineFinder.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/CMakeLists.txt
+++ b/Gem/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/CMakeLists.txt
+++ b/Gem/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Source/AtomTestModule.cpp
+++ b/Gem/Code/Source/AtomTestModule.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/AtomTestModule.cpp
+++ b/Gem/Code/Source/AtomTestModule.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/atomtest_files.cmake
+++ b/Gem/Code/atomtest_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/atomtest_files.cmake
+++ b/Gem/Code/atomtest_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/atomtest_ios_files.cmake
+++ b/Gem/Code/atomtest_ios_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/atomtest_ios_files.cmake
+++ b/Gem/Code/atomtest_ios_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/atomtest_mac_files.cmake
+++ b/Gem/Code/atomtest_mac_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/atomtest_mac_files.cmake
+++ b/Gem/Code/atomtest_mac_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/enabled_gems.cmake
+++ b/Gem/Code/enabled_gems.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/enabled_gems.cmake
+++ b/Gem/Code/enabled_gems.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/PythonTests/Automated/TestData/AsyncAssetLoadTest/ShaderBlendingOn.azsl.txt
+++ b/Gem/PythonTests/Automated/TestData/AsyncAssetLoadTest/ShaderBlendingOn.azsl.txt
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project. 
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/PythonTests/Automated/__init__.py
+++ b/Gem/PythonTests/Automated/__init__.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Gem/PythonTests/Automated/atom_utils/__init__.py
+++ b/Gem/PythonTests/Automated/atom_utils/__init__.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Gem/PythonTests/Automated/atom_utils/automated_test_base.py
+++ b/Gem/PythonTests/Automated/atom_utils/automated_test_base.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/atom_utils/automated_test_utils.py
+++ b/Gem/PythonTests/Automated/atom_utils/automated_test_utils.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Gem/PythonTests/Automated/atom_utils/hydra_editor_utils.py
+++ b/Gem/PythonTests/Automated/atom_utils/hydra_editor_utils.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Gem/PythonTests/Automated/atom_utils/hydra_test_utils.py
+++ b/Gem/PythonTests/Automated/atom_utils/hydra_test_utils.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Gem/PythonTests/Automated/atom_utils/material_editor_utils.py
+++ b/Gem/PythonTests/Automated/atom_utils/material_editor_utils.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/atom_utils/network_utils.py
+++ b/Gem/PythonTests/Automated/atom_utils/network_utils.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Gem/PythonTests/Automated/atom_utils/registry_utils.py
+++ b/Gem/PythonTests/Automated/atom_utils/registry_utils.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Gem/PythonTests/Automated/atom_utils/screenshot_utils.py
+++ b/Gem/PythonTests/Automated/atom_utils/screenshot_utils.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Gem/PythonTests/Automated/conftest.py
+++ b/Gem/PythonTests/Automated/conftest.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/__init__.py
+++ b/Gem/PythonTests/Automated/test_suites/__init__.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Gem/PythonTests/Automated/test_suites/main/AllLevelsOpenClose_test.py
+++ b/Gem/PythonTests/Automated/test_suites/main/AllLevelsOpenClose_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/main/AllLevelsOpenClose_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/main/AllLevelsOpenClose_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/main/__init__.py
+++ b/Gem/PythonTests/Automated/test_suites/main/__init__.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Gem/PythonTests/Automated/test_suites/periodic/ActorComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/ActorComponent_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/ActorComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/ActorComponent_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/AllComponentsBasicTests_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/AllComponentsBasicTests_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/AllComponentsBasicTests_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/AllComponentsBasicTests_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/AllComponentsIndepthDecalGridTests_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/AllComponentsIndepthDecalGridTests_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/AllComponentsIndepthTests_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/AllComponentsIndepthTests_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/AllComponentsIndepthTests_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/AllComponentsIndepthTests_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/AssetCollectionLoadManager_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/AssetCollectionLoadManager_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/AssetCollectionLoadManager_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/AssetCollectionLoadManager_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/BasicLevelSetup_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/BasicLevelSetup_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/ChangingMaterialTabs_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/ChangingMaterialTabs_test.py
@@ -1,12 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
 import os

--- a/Gem/PythonTests/Automated/test_suites/periodic/ChangingMaterialTabs_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/ChangingMaterialTabs_test_case.py
@@ -1,12 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+SPDX-License-Identifier: Apache-2.0 OR MIT
 
 Test for Changing Material Tabs
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/CreatingChildMaterials_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/CreatingChildMaterials_test.py
@@ -1,12 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
 import os

--- a/Gem/PythonTests/Automated/test_suites/periodic/CreatingChildMaterials_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/CreatingChildMaterials_test_case.py
@@ -1,12 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+SPDX-License-Identifier: Apache-2.0 OR MIT
 
 Test for Creating child materials
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/CreatingSubfoldersInLibrary_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/CreatingSubfoldersInLibrary_test.py
@@ -1,12 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
 import os

--- a/Gem/PythonTests/Automated/test_suites/periodic/CreatingSubfoldersInLibrary_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/CreatingSubfoldersInLibrary_test_case.py
@@ -1,12 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+SPDX-License-Identifier: Apache-2.0 OR MIT
 
 
 Creating Subfolders within Library

--- a/Gem/PythonTests/Automated/test_suites/periodic/DecalComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/DecalComponent_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/DecalComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/DecalComponent_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/DirectionalLightComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/DirectionalLightComponent_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/DirectionalLightComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/DirectionalLightComponent_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/ExposureComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/ExposureComponent_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/ExposureComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/ExposureComponent_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/GridComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/GridComponent_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/GridComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/GridComponent_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/HDRiSkyboxComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/HDRiSkyboxComponent_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/HDRiSkyboxComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/HDRiSkyboxComponent_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/LaunchEditorMaterialEditorRHIArgs_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/LaunchEditorMaterialEditorRHIArgs_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Gem/PythonTests/Automated/test_suites/periodic/LevelsLauncher_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/LevelsLauncher_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Gem/PythonTests/Automated/test_suites/periodic/MaterialBrowserSearchAssets_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MaterialBrowserSearchAssets_test.py
@@ -1,12 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
 import os

--- a/Gem/PythonTests/Automated/test_suites/periodic/MaterialBrowserSearchAssets_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MaterialBrowserSearchAssets_test_case.py
@@ -1,12 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+SPDX-License-Identifier: Apache-2.0 OR MIT
 
 Searching Assets in Material Browser
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/MaterialComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MaterialComponent_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/MaterialComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MaterialComponent_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditorBasicTests_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditorBasicTests_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditorBasicTests_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditorBasicTests_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditorExitFromFileMenu_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditorExitFromFileMenu_test.py
@@ -1,12 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
 import os

--- a/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditorExitFromFileMenu_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditorExitFromFileMenu_test_case.py
@@ -1,12 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+SPDX-License-Identifier: Apache-2.0 OR MIT
 
 Exiting Client Via File Menu
 """

--- a/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditor_EnableGridShadowCatcherLight_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditor_EnableGridShadowCatcherLight_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditor_EnableGridShadowCatcherLight_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MaterialEditor_EnableGridShadowCatcherLight_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/MeshComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MeshComponent_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/MeshComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MeshComponent_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/MeshGroupImporting_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MeshGroupImporting_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/MeshGroupImporting_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MeshGroupImporting_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/MeshScaling_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MeshScaling_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/MeshScaling_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/MeshScaling_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/NonMaterialAssetsExcludedInBrowser_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/NonMaterialAssetsExcludedInBrowser_test.py
@@ -1,12 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
 import os

--- a/Gem/PythonTests/Automated/test_suites/periodic/NonMaterialAssetsExcludedInBrowser_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/NonMaterialAssetsExcludedInBrowser_test_case.py
@@ -1,12 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+SPDX-License-Identifier: Apache-2.0 OR MIT
 
 Non-Material based assets excluded from Browser
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/OpeningFileSourceLocation_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/OpeningFileSourceLocation_test.py
@@ -1,11 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
 import os

--- a/Gem/PythonTests/Automated/test_suites/periodic/OpeningFileSourceLocation_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/OpeningFileSourceLocation_test_case.py
@@ -1,11 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
 
 Opening File Source Location
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/OpeningMaterialAssetBrowser_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/OpeningMaterialAssetBrowser_test.py
@@ -1,11 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
 import os

--- a/Gem/PythonTests/Automated/test_suites/periodic/OpeningMaterialAssetBrowser_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/OpeningMaterialAssetBrowser_test_case.py
@@ -1,12 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+SPDX-License-Identifier: Apache-2.0 OR MIT
 
 Opening material in Material Browser
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/PhysicalSkyComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/PhysicalSkyComponent_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/PhysicalSkyComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/PhysicalSkyComponent_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/PostFxGradientWeightModifierComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/PostFxGradientWeightModifierComponent_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/PostFxGradientWeightModifierComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/PostFxGradientWeightModifierComponent_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/PostFxShapeWeightModifierComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/PostFxShapeWeightModifierComponent_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/PostFxShapeWeightModifierComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/PostFxShapeWeightModifierComponent_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/RadiusWeightModifierComponent_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/RadiusWeightModifierComponent_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/RadiusWeightModifierComponent_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/RadiusWeightModifierComponent_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/ReloadingConfigurationFiles_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/ReloadingConfigurationFiles_test.py
@@ -1,11 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
 import os

--- a/Gem/PythonTests/Automated/test_suites/periodic/ReloadingConfigurationFiles_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/ReloadingConfigurationFiles_test_case.py
@@ -1,12 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+SPDX-License-Identifier: Apache-2.0 OR MIT
 
 Reloading Configuration Files in Material Editor
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/SelectingInBrowserViaViewportTab_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/SelectingInBrowserViaViewportTab_test.py
@@ -1,12 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
 import os

--- a/Gem/PythonTests/Automated/test_suites/periodic/SelectingInBrowserViaViewportTab_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/SelectingInBrowserViaViewportTab_test_case.py
@@ -1,12 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+SPDX-License-Identifier: Apache-2.0 OR MIT
 
 
 Selecting in Browser via Viewport Tab

--- a/Gem/PythonTests/Automated/test_suites/periodic/SelectingOpenMaterials_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/SelectingOpenMaterials_test.py
@@ -1,12 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
 import os

--- a/Gem/PythonTests/Automated/test_suites/periodic/SelectingOpenMaterials_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/SelectingOpenMaterials_test_case.py
@@ -1,12 +1,8 @@
 """
-All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-its licensors.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
-For complete copyright and license terms please see the LICENSE at the root of this
-distribution (the "License"). All use of this software is governed by the License,
-or, if provided, by the license below or the license accompanying this file. Do not
-remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+SPDX-License-Identifier: Apache-2.0 OR MIT
 
 
 Hydra script that opens couple of materials, and then tries to open the same material again

--- a/Gem/PythonTests/Automated/test_suites/periodic/TransformManipulators_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/TransformManipulators_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/TransformManipulators_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/TransformManipulators_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/ViewAssetBrowserMaterialInspector_test.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/ViewAssetBrowserMaterialInspector_test.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Gem/PythonTests/Automated/test_suites/periodic/ViewAssetBrowserMaterialInspector_test_case.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/ViewAssetBrowserMaterialInspector_test_case.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Gem/PythonTests/Automated/test_suites/periodic/__init__.py
+++ b/Gem/PythonTests/Automated/test_suites/periodic/__init__.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Gem/PythonTests/Automated/test_suites/smoke/__init__.py
+++ b/Gem/PythonTests/Automated/test_suites/smoke/__init__.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Gem/PythonTests/CMakeLists.txt
+++ b/Gem/PythonTests/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/PythonTests/CMakeLists.txt
+++ b/Gem/PythonTests/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Levels/NormalMapping/TestNormalMapping.azsl
+++ b/Levels/NormalMapping/TestNormalMapping.azsl
@@ -1,6 +1,7 @@
 
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Levels/NormalMapping/TestNormalMapping.azsl
+++ b/Levels/NormalMapping/TestNormalMapping.azsl
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Materials/UVs.azsl
+++ b/Materials/UVs.azsl
@@ -1,6 +1,7 @@
 
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Materials/UVs.azsl
+++ b/Materials/UVs.azsl
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/ShaderLib/scenesrg.srgi
+++ b/ShaderLib/scenesrg.srgi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/ShaderLib/scenesrg.srgi
+++ b/ShaderLib/scenesrg.srgi
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/ShaderLib/viewsrg.srgi
+++ b/ShaderLib/viewsrg.srgi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/ShaderLib/viewsrg.srgi
+++ b/ShaderLib/viewsrg.srgi
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/CommonVS.azsli
+++ b/Shaders/CommonVS.azsli
@@ -1,6 +1,7 @@
 
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/CommonVS.azsli
+++ b/Shaders/CommonVS.azsli
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/atomtest_asset_files.cmake
+++ b/atomtest_asset_files.cmake
@@ -1,5 +1,6 @@
 # 
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/atomtest_asset_files.cmake
+++ b/atomtest_asset_files.cmake
@@ -1,7 +1,7 @@
 # 
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 # 

--- a/generate_asset_cmake.bat
+++ b/generate_asset_cmake.bat
@@ -1,7 +1,7 @@
 @ECHO off
 REM Copyright (c) Contributors to the Open 3D Engine Project.
 REM For complete copyright and license terms please see the LICENSE at the root of this distribution.
-REM 
+REM
 REM SPDX-License-Identifier: Apache-2.0 OR MIT
 setlocal enabledelayedexpansion
 

--- a/generate_asset_cmake.bat
+++ b/generate_asset_cmake.bat
@@ -1,5 +1,6 @@
 @ECHO off
-REM Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+REM Copyright (c) Contributors to the Open 3D Engine Project.
+REM For complete copyright and license terms please see the LICENSE at the root of this distribution.
 REM 
 REM SPDX-License-Identifier: Apache-2.0 OR MIT
 setlocal enabledelayedexpansion
@@ -15,7 +16,8 @@ set OUTPUT_FILE=atomtest_asset_files.cmake
 
 :: Write copyright header to top of file
 echo # > %OUTPUT_FILE%
-echo # Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution. >> %OUTPUT_FILE%
+echo # Copyright (c) Contributors to the Open 3D Engine Project. >> %OUTPUT_FILE%
+echo # For complete copyright and license terms please see the LICENSE at the root of this distribution. >> %OUTPUT_FILE%
 echo # >> %OUTPUT_FILE%
 echo # SPDX-License-Identifier: Apache-2.0 OR MIT >> %OUTPUT_FILE%
 echo # >> %OUTPUT_FILE%


### PR DESCRIPTION
The original copyright headers for O3DE went over 140 characters, which is causing clang-format to automatically wrap it from:

```
/*
 * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
 * 
 * SPDX-License-Identifier: Apache-2.0 OR MIT
 *
 */
 ```
 
 to:
 
 ```
 /*
 * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of
 * this distribution.
 *
 * SPDX-License-Identifier: Apache-2.0 OR MIT
 *
 */
 ```
 
 So to reduce this unnecessary reformatting, and to make the copyright statement shorter in general (for all source code files), we are updating it to (C-style example):
 
 ```
 /*
 * Copyright (c) Contributors to the Open 3D Engine Project. 
 * For complete copyright and license terms please see the LICENSE at the root of this distribution.
 *
 * SPDX-License-Identifier: Apache-2.0 OR MIT
 *
 */
 ```
 
 Note: The copyright submission validator will still pass the original single-line version, as it is still a valid statement.
 