### PR TITLE
Enable the GameStateSamples Gem.

### DIFF
--- a/Gem/Code/enabled_gems.cmake
+++ b/Gem/Code/enabled_gems.cmake
@@ -27,4 +27,5 @@ set(ENABLED_GEMS
     EditorPythonBindings
     QtForPython
     DccScriptingInterface
+    GameStateSamples
 )


### PR DESCRIPTION
This namely provides a simple main menu from which the user can open any level within the project, and a simple pause menu from which the user can return to the main menu in order to select a different level to open.

The user can interact with both menus using mouse/keyboard, gamepad, or touch screen, and the menus are only show when running the game launcher (not the editor).

https://user-images.githubusercontent.com/21963101/143622830-f360e032-a84c-414a-bae4-17450c488b5d.mp4

Signed-off-by: bosnichd <bosnichd@amazon.com